### PR TITLE
Add scraped page archiver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+# It's easy to add more libraries or choose different versions. Any libraries
+# specified here will be installed and made available to your morph.io scraper.
+# Find out more: https://morph.io/documentation/ruby
+
+source 'https://rubygems.org'
+
+ruby '2.0.0'
+
+gem 'scraperwiki', git: 'https://github.com/openaustralia/scraperwiki-ruby.git', branch: 'morph_defaults'
+gem 'open-uri-cached'
+gem 'scraped_page_archive'
+gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,54 @@
+GIT
+  remote: https://github.com/openaustralia/scraperwiki-ruby.git
+  revision: fc50176812505e463077d5c673d504a6a234aa78
+  branch: morph_defaults
+  specs:
+    scraperwiki (3.0.1)
+      httpclient
+      sqlite_magic
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    git (1.3.0)
+    hashdiff (0.3.0)
+    httpclient (2.8.2.4)
+    mini_portile2 (2.1.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    open-uri-cached (0.0.5)
+    public_suffix (2.0.4)
+    safe_yaml (1.0.4)
+    scraped_page_archive (0.5.0)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
+    sqlite3 (1.3.12)
+    sqlite_magic (0.0.6)
+      sqlite3
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri
+  open-uri-cached
+  scraped_page_archive
+  scraperwiki!
+
+RUBY VERSION
+   ruby 2.0.0p648
+
+BUNDLED WITH
+   1.13.5

--- a/scraper.rb
+++ b/scraper.rb
@@ -4,9 +4,10 @@
 require 'scraperwiki'
 require 'nokogiri'
 require 'date'
-require 'open-uri'
+# require 'open-uri'
 require 'date'
 require 'uri'
+require 'scraped_page_archive/open-uri'
 
 # require 'colorize'
 # require 'pry'


### PR DESCRIPTION
## What does this do?

Uses scraped-page-archive to archive all pages scraped.

## Why is this needed?

There's an election coming up soon ([7th December](https://en.wikipedia.org/wiki/Ghanaian_general_election,_2016)), and it's likely that the data on the official site will disappear, meaning any data we're not already picking up will be lost. Archiving it now gives us the chance to go back and re-scrape later even if it disappears.

## Relevant Issue(s):

https://github.com/everypolitician/everypolitician-data/issues/20544

## Checklists:

### [Scraper change](https://github.com/everypolitician/everypolitician/wiki/Scraper-Change-checklist):
* [ ] 1. scraper is on Morph.io under the "everypolitician-scrapers" group? — no, it's still at https://morph.io/tmtmtmtm/ghana-parliament, but there's little point in moving it this close to the election.
* [x] 2. scraper's GitHub "Website" link points at morph.io page?
* [ ] 3. scraper is set to auto-run? — not yet: @tmtmtmtm This needs to be set on Morph.
* [x] 4. scraper is configured for archiving? — that's what this PR is doing!
* [x] 5. legislature has a scraper webhook set? — triggered from https://morph.io/tmtmtmtm/ghana-parliament-wikidata

### [Adding Archiving](https://github.com/everypolitician/everypolitician/wiki/Adding-Archiving-to-Scraper-checklist):
* [x] 1: we are using at least version 0.5 of scraped-page-archive-gem? — version 0.5.0
* [x] 2: scraper uses scraped-page-archive gem directly or via a suitable strategy? — uses it directly
* [ ] 3: MORPH_SCRAPER_CACHE_GITHUB_REPO_URL is configured — not yet. @tmtmtmtm this needs configured on morph
* [x] 4: pages are being archived in new branch of correct scraper repo?

### [Gemfile change](https://github.com/everypolitician/everypolitician/wiki/Gemfile-checklist):
* [x] 1. all links are secure?
* [x] 2. links to Github use `github:` protocol, not simply `git:`?
* [x] 3. formatting is consistent with our normal Rubocop setup?