### PR TITLE
Clean out database on each run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,15 +7,18 @@ ruby '2.3.3'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 gem 'minitest'
+gem 'minitest-around'
 gem 'minitest-vcr'
 gem 'nokogiri'
 gem 'open-uri-cached'
 gem 'pry'
 gem 'rake'
+gem 'rest-client'
 gem 'rubocop'
 gem 'scraped', github: 'everypolitician/scraped'
 gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'
 gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
                    branch: 'morph_defaults'
+gem 'table_unspanner', github: 'everypolitician/table_unspanner'
 gem 'vcr'
 gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/everypolitician/scraped.git
-  revision: 44f8c0baa3e1c6860fed85d3f0f8e24f7c417b16
+  revision: c3fc06e1c44beb9027a4dbe4c8bb471d803b27ce
   specs:
-    scraped (0.1.0)
+    scraped (0.2.0)
       field_serializer (>= 0.3.0)
       nokogiri
       require_all
@@ -14,6 +14,13 @@ GIT
     scraped_page_archive (0.5.0)
       git (~> 1.3.0)
       vcr-archive (~> 0.3.0)
+
+GIT
+  remote: https://github.com/everypolitician/table_unspanner.git
+  revision: a70a98a104a75b470f4ea339fdd728366a40b4d8
+  specs:
+    table_unspanner (0.1.0)
+      nokogiri
 
 GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
@@ -30,29 +37,39 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     ast (2.3.0)
-    coderay (1.1.1)
+    coderay (1.1.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    domain_name (0.5.20161129)
+      unf (>= 0.0.5, < 1.0.0)
     field_serializer (0.3.0)
     git (1.3.0)
-    hashdiff (0.3.0)
-    httpclient (2.8.2.4)
+    hashdiff (0.3.1)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    httpclient (2.6.0.1)
     method_source (0.8.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minispec-metadata (2.0.0)
       minitest
     minitest (5.10.1)
+    minitest-around (0.4.0)
+      minitest (~> 5.0)
     minitest-vcr (1.4.0)
       minispec-metadata (~> 2.0)
       minitest (>= 4.7.5)
       vcr (>= 2.9)
-    nokogiri (1.6.8.1)
+    netrc (0.11.0)
+    nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     open-uri-cached (0.0.5)
     parser (2.3.3.1)
       ast (~> 2.2)
     powerpack (0.1.1)
-    pry (0.10.4)
+    pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
@@ -60,6 +77,10 @@ GEM
     rainbow (2.1.0)
     rake (12.0.0)
     require_all (1.3.3)
+    rest-client (2.0.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rubocop (0.46.0)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
@@ -69,9 +90,12 @@ GEM
     ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
     slop (3.6.0)
-    sqlite3 (1.3.12)
-    sqlite_magic (0.0.6)
+    sqlite3 (1.3.10)
+    sqlite_magic (0.0.3)
       sqlite3
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     unicode-display_width (1.1.2)
     vcr (3.0.3)
     vcr-archive (0.3.0)
@@ -87,15 +111,18 @@ PLATFORMS
 
 DEPENDENCIES
   minitest
+  minitest-around
   minitest-vcr
   nokogiri
   open-uri-cached
   pry
   rake
+  rest-client
   rubocop
   scraped!
   scraped_page_archive!
   scraperwiki!
+  table_unspanner!
   vcr
   webmock
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -108,4 +108,5 @@ def scrape_mp(url)
   ScraperWiki.save_sqlite(%i(id term), data)
 end
 
+ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 scrape_list 'http://www.parliament.gh/parliamentarians'

--- a/scraper.rb
+++ b/scraper.rb
@@ -20,12 +20,6 @@ def datefrom(date)
   Date.parse(date)
 end
 
-class String
-  def tidy
-    gsub(/[[:space:]]+/, ' ').strip
-  end
-end
-
 class MembersPage < Scraped::HTML
   field :mp_urls do
     noko.css('#mid_content_conteiner .mp_repeater').map do |mpbox|

--- a/scraper.rb
+++ b/scraper.rb
@@ -103,8 +103,8 @@ def scrape_list(url)
 end
 
 def scrape_mp(url)
-  page = MemberPage.new(response: Scraped::Request.new(url: url).response)
-  data = page.to_h
+  data = MemberPage.new(response: Scraped::Request.new(url: url).response).to_h
+  # puts data
   ScraperWiki.save_sqlite(%i(id term), data)
 end
 


### PR DESCRIPTION
The morph database currently has data that has already been archived off
into a manual file. We could just clean the database as a one-off, but
current practice is to clean out the database on each run so that we
spot problems sooner.