### PR TITLE
Remove superfluous noko_for method

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -10,10 +10,6 @@ require 'open-uri/cached'
 OpenURI::Cache.cache_path = '.cache'
 # require 'scraped_page_archive/open-uri'
 
-def noko_for(url)
-  Nokogiri::HTML(open(url).read)
-end
-
 def datefrom(date)
   return if date.empty?
   Date.parse(date)


### PR DESCRIPTION
This method is no longer called.

This is a step towards reworking the scraper for change in site layout. https://github.com/everypolitician-scrapers/ghana-parliament/pull/7